### PR TITLE
Avoid race condition when renewing certificates

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -311,4 +311,5 @@ class Certificate(object):
             LOG.info('[%s] Reloading service specified: %s' %
                      (self.name, self.service_name))
             command = 'systemctl reload %s' % self.service_name
-            subprocess.Popen(command.split())
+            p = subprocess.Popen(command.split())
+            p.wait()


### PR DESCRIPTION
When renewing several certificates, service could fail to reload
properly due to a race condition, if the reload happens while lecm
is re-writing the pem file.

By default, subprocess.Popen() is not blocking, to ensure we do not face
this race condition again, we make it blocking, by waiting for the
process to terminante.
