### PR TITLE
Do not clean filesystem before requesting certs

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -284,25 +284,6 @@ class Certificate(object):
             self._create_certificate()
 
     def renew(self):
-        try:
-            LOG.debug('[%s] Removing exising CSR: %s/csr/%s.csr' %
-                      (self.name, self.path, self.name))
-            os.remove('%s/csr/%s.csr' % (self.path, self.name))
-        except OSError:
-            pass
-        try:
-            LOG.debug('[%s] Removing exising PEM file: %s/pem/%s.pem' %
-                      (self.name, self.path, self.name))
-            os.remove('%s/pem/%s.pem' % (self.path, self.name))
-        except OSError:
-            pass
-        try:
-            LOG.debug('[%s] Removing exising cert file: %s/certs/%s.crt' %
-                      (self.name, self.path, self.name))
-            os.remove('%s/certs/%s.crt' % (self.path, self.name))
-        except OSError:
-            pass
-
         self._create_csr()
         self._create_certificate()
 


### PR DESCRIPTION
The .csr, .crt and .pem files are currently removed before requesting
the certificate from Let's Encrypt. This can lead to cases where - for
any reason - the certificate is not returned, and then .crt and .pem
files are lost.

All three of them are properly (re)generated during the
_create_certificate() function, overriding if necessary currently
present files.
