### PR TITLE
Add support for platforms using sysv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,8 @@ Every parameters are either applicable globally or within the scope of a certifi
 +------------------------+----------------+---------+-------------------------------------------------------------------------------+
 | service_name           | global, backup | httpd   | Service that needs to be reloaded for the change to be taken in consideration |
 +------------------------+----------------+---------+-------------------------------------------------------------------------------+
+| service_provider       | global, backup | systemd | Service management system (Possible: systemd, sysv)                           |
++------------------------+----------------+---------+-------------------------------------------------------------------------------+
 
 
 Configuration file example

--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -41,6 +41,7 @@ class Certificate(object):
         self.remaining_days = conf.get('remaining_days', 10)
         self.days_before_expiry = self.get_days_before_expiry()
         self.service_name = conf.get('service_name', 'httpd')
+        self.service_provider = conf.get('service_provider', 'systemd')
 
         self.subject = {
           'C': conf.get('countryName'),
@@ -291,6 +292,9 @@ class Certificate(object):
         if self.service_name:
             LOG.info('[%s] Reloading service specified: %s' %
                      (self.name, self.service_name))
-            command = 'systemctl reload %s' % self.service_name
+            if self.service_provider == 'sysv':
+                command = 'service %s reload' % self.service_name
+            else:
+                command = 'systemctl reload %s' % self.service_name
             p = subprocess.Popen(command.split())
             p.wait()

--- a/lecm/configuration.py
+++ b/lecm/configuration.py
@@ -26,7 +26,7 @@ _FIELDS = ['type', 'size', 'digest', 'version', 'subjectAltName',
            'countryName', 'stateOrProvinceName', 'localityName',
            'organizationName', 'organizationUnitName', 'commonName',
            'emailAddress', 'account_key_name', 'path', 'remaining_days',
-           'service_name']
+           'service_name', 'service_provider']
 
 
 def check_configuration_file_existence(configuration_file_path=None):

--- a/sample/lecm.conf
+++ b/sample/lecm.conf
@@ -5,6 +5,7 @@ size: 4096
 emailAddress: distributed-ci@redhat.com
 account_key_name: myhost.key
 service_name: httpd
+service_provider: systemd
 account_key_name: myhost.key
 
 certificates:


### PR DESCRIPTION
lecm was only able to manage the reload of the web server of the service
on a systemd based platform. This commit aims to add support for
platforms that still relies on sysv platforms surch as FreeBSD.
