### PR TITLE
Run the reload command only when necessary

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -302,12 +302,4 @@ class Certificate(object):
         self._create_certificate()
 
     def reload_service(self):
-        if self.service_name:
-            LOG.info('[%s] Reloading service specified: %s' %
-                     (self.name, self.service_name))
-            if self.service_provider == 'sysv':
-                command = 'service %s reload' % self.service_name
-            else:
-                command = 'systemctl reload %s' % self.service_name
-            p = subprocess.Popen(command.split())
-            p.wait()
+        utils.reload_service(self.service_name, self.service_provider)

--- a/lecm/utils.py
+++ b/lecm/utils.py
@@ -13,13 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from prettytable import PrettyTable
+
 import copy
 import logging
 import os
 import platform
 import subprocess
-
-from prettytable import PrettyTable
 
 LOG = logging.getLogger(__name__)
 
@@ -62,3 +62,15 @@ def enforce_selinux_context(output_directory):
             p = subprocess.Popen(command.split(), stdout=FNULL,
                                  stderr=subprocess.STDOUT)
             p.wait()
+
+
+def reload_service(service_name, service_provider):
+
+    if service_name:
+        LOG.info('Reloading service specified: %s' % service_name)
+        if service_provider == 'sysv':
+            command = 'service %s reload' % service_name
+        else:
+            command = 'systemctl reload %s' % service_name
+        p = subprocess.Popen(command.split())
+        p.wait()


### PR DESCRIPTION
Before this patch the reload command was run for each and every new
certificate generation or renewal even if all certificates were used
for the same service.

From now it will reload the services only when necessary, so if all
services uses the same service_name then it will be reload only once.

Fix #20 
