### PR TITLE
certificates: Allow one to reload multiple service

### DIFF
--- a/lecm/utils.py
+++ b/lecm/utils.py
@@ -67,10 +67,14 @@ def enforce_selinux_context(output_directory):
 def reload_service(service_name, service_provider):
 
     if service_name:
-        LOG.info('Reloading service specified: %s' % service_name)
-        if service_provider == 'sysv':
-            command = 'service %s reload' % service_name
-        else:
-            command = 'systemctl reload %s' % service_name
-        p = subprocess.Popen(command.split())
-        p.wait()
+        if not isinstance(service_name, list):
+            service_name = [service_name]
+
+        for service in service_name:
+            LOG.info('Reloading service specified: %s' % service)
+            if service_provider == 'sysv':
+                command = 'service %s reload' % service
+            else:
+                command = 'systemctl reload %s' % service
+            p = subprocess.Popen(command.split())
+            p.wait()

--- a/sample/lecm-multipleservices.conf
+++ b/sample/lecm-multipleservices.conf
@@ -1,0 +1,13 @@
+---
+path: /etc/letsencrypt
+service_name: nginx
+
+certificates:
+  my.example.com:
+    service_name:
+      - postfix
+      - dovecot
+  my-test.example.com:
+    subjectAltName:
+      - my-test.example.com
+      - my-test1.example.com


### PR DESCRIPTION
Currently, a user can reload only a single service per certificate. It
can happen that a certificate is shared amongst services and multiple
services might need to be reloaded.

Imagine, one shares a single certificate for both Postfix and Dovecot
services. One could reload both services using the following syntax:

```
certificates:
  mail.example.com:
    service_name:
      - postfix
      - dovecot
```

Fix #32 