### PR TITLE
certificates: Allow one to use Let's Encrypt staging API

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -84,12 +84,12 @@ if its expiry date is lower than the ``remainin_days`` value.
 
 .. code-block::
 
-  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+-----------------------------------------------------------+------+------+--------+------+
-  |               Item               |     Status    |                          subjectAltName                          |        emailAddress       |                          Location                         | Type | Size | Digest | Days |
-  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+-----------------------------------------------------------+------+------+--------+------+
-  |   lecm-test.distributed-ci.io    |   Generated   |                 DNS:lecm-test.distributed-ci.io                  | distributed-ci@redhat.com |    /etc/letsencrypt/pem/lecm-test.distributed-ci.io.pem   | RSA  | 4096 | sha256 |  89  |
-  | lecm-test-test.distributed-ci.io | Not-Generated | DNS;lecm-test-test.distributed-ci.io,DNS:lecm.distributedi-ci.io | distributed-ci@redhat.com | /etc/letsencrypt/pem/lecm-test-test.distributed-ci.io.pem | RSA  | 2048 | sha256 | N/A  |
-  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+-----------------------------------------------------------+------+------+--------+------+
+  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------+-----------------------------------------------------------+------+------+--------+------+
+  |               Item               |     Status    |                          subjectAltName                          |        emailAddress       |  Environment |                          Location                         | Type | Size | Digest | Days |
+  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------+-----------------------------------------------------------+------+------+--------+------+
+  |   lecm-test.distributed-ci.io    |   Generated   |                 DNS:lecm-test.distributed-ci.io                  | distributed-ci@redhat.com |  production  |    /etc/letsencrypt/pem/lecm-test.distributed-ci.io.pem   | RSA  | 4096 | sha256 |  89  |
+  | lecm-test-test.distributed-ci.io | Not-Generated | DNS;lecm-test-test.distributed-ci.io,DNS:lecm.distributedi-ci.io | distributed-ci@redhat.com |    staging   | /etc/letsencrypt/pem/lecm-test-test.distributed-ci.io.pem | RSA  | 2048 | sha256 | N/A  |
+  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------|-----------------------------------------------------------+------+------+--------+------+
 
 
 Configuration
@@ -133,6 +133,8 @@ Every parameters are either applicable globally or within the scope of a certifi
 | service_name           | global, certificate | httpd             | Service that needs to be reloaded for the change to be taken in consideration |
 +------------------------+---------------------+-------------------+-------------------------------------------------------------------------------+
 | service_provider       | global, certificate | systemd           | Service management system (Possible: systemd, sysv)                           |
++------------------------+---------------------+-------------------+-------------------------------------------------------------------------------+
+| environment            | global, certificate | production        | Let's Encrypt environment to use (Possible: production, staging)              |
 +------------------------+---------------------+-------------------+-------------------------------------------------------------------------------+
 
 

--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -28,6 +28,9 @@ LOG = logging.getLogger(__name__)
 _INTERMEDIATE_CERTIFICATE_URL = \
     'https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem'
 
+_STAGING_URL = \
+    'https://acme-staging.api.letsencrypt.org'
+
 
 class Certificate(object):
 
@@ -38,6 +41,7 @@ class Certificate(object):
         self.size = conf.get('size', 4096)
         self.digest = conf.get('digest', 'sha256')
         self.version = conf.get('version', 3)
+        self.environment = conf.get('environment', 'production')
         self.subjectAltName = self.normalize_san(conf.get('subjectAltName'))
         self.account_key_name = conf.get('account_key_name',
                                          'account_%s.key' % socket.getfqdn())
@@ -229,6 +233,11 @@ class Certificate(object):
                                                   self.account_key_name,
                                                   self.path, self.name,
                                                   self.path, self.name)
+
+        if self.environment == 'staging':
+            LOG.info('[%s] Using Let''s Encrypt staging API: %s' %
+                     (self.name, _STAGING_URL))
+            command = '%s --ca %s' % (command, _STAGING_URL)
 
         cert_file_f = open('%s/certs/%s.crt.new' % (self.path, self.name), 'w')
 

--- a/lecm/configuration.py
+++ b/lecm/configuration.py
@@ -26,7 +26,7 @@ _FIELDS = ['type', 'size', 'digest', 'version', 'subjectAltName',
            'countryName', 'stateOrProvinceName', 'localityName',
            'organizationName', 'organizationUnitName', 'commonName',
            'emailAddress', 'account_key_name', 'path', 'remaining_days',
-           'service_name', 'service_provider']
+           'service_name', 'service_provider', 'environment']
 
 
 def check_configuration_file_existence(configuration_file_path=None):

--- a/lecm/lists.py
+++ b/lecm/lists.py
@@ -45,6 +45,7 @@ def list_details(certificates):
               ['Status', []],
               ['subjectAltName', []],
               ['emailAddress', []],
+              ['Environment', []],
               ['Location', []],
               ['Type', []],
               ['Size', []],
@@ -60,10 +61,11 @@ def list_details(certificates):
             result[1][1].append('Not-Generated')
         result[2][1].append(cert.subjectAltName)
         result[3][1].append(cert.subject['emailAddress'])
-        result[4][1].append('%s/pem/%s.pem' % (cert.path, cert.name))
-        result[5][1].append(cert.type)
-        result[6][1].append(cert.size)
-        result[7][1].append(cert.digest)
-        result[8][1].append(cert.days_before_expiry)
+        result[4][1].append(cert.environment)
+        result[5][1].append('%s/pem/%s.pem' % (cert.path, cert.name))
+        result[6][1].append(cert.type)
+        result[7][1].append(cert.size)
+        result[8][1].append(cert.digest)
+        result[9][1].append(cert.days_before_expiry)
 
     utils.output_informations(result)

--- a/sample/lecm-environment.conf
+++ b/sample/lecm-environment.conf
@@ -1,0 +1,7 @@
+---
+path: /etc/letsencrypt
+
+certificates:
+  my.example.com:
+  my-staging.example.com:
+    environment: staging


### PR DESCRIPTION
Let's Encrypt offers a staging API for one to do its tests while getting
the setup right. This would prevent the user from reaching the rate
limit with incorrect data.

lecm does now support the API selection via the 'environment' variable,
that defaults to 'production'.

Example:

```

---
path: /etc/ssl

certificates:
  my.example.com:
  my-staging.example.com:
    environment: staging
```

Fix #40 