### PR TITLE
Renew: Do not fail when no certificate has already been generated

### DIFF
--- a/lecm/shell.py
+++ b/lecm/shell.py
@@ -83,10 +83,12 @@ def main():
                             cert.reload_service()
             elif options.renew:
                 if options.noop:
-                    if cert.days_before_expiry <= cert.remaining_days:
+                    if isinstance(cert.days_before_expiry, int) and \
+                       cert.days_before_expiry <= cert.remaining_days:
                         noop_holder[name] = parameters
                 else:
-                    if cert.days_before_expiry <= cert.remaining_days:
+                    if isinstance(cert.days_before_expiry, int) and \
+                       cert.days_before_expiry <= cert.remaining_days:
                         cert.renew()
                         _CHANGE = True
                         # If the service for a specific certificate is


### PR DESCRIPTION
`lecm` is failing when `lecm --renew` is launched and certifates listed
have not been generated yet because of Days being the literal string
'N/A'.

This commit fixes that.

Fic #46 