### PR TITLE
 Display a flag showing if conf and cert are in sync

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,12 +69,12 @@ if its expiry date is lower than the ``remainin_days`` value.
 
 .. code-block::
 
-  +----------------------------------+---------------+------------------------------------------------------------------+-----------------------------------------------------------+------+
-  |               Item               |     Status    |                          subjectAltName                          |                          Location                         | Days |
-  +----------------------------------+---------------+------------------------------------------------------------------+-----------------------------------------------------------+------+
-  |   lecm-test.distributed-ci.io    |   Generated   |                 DNS:lecm-test.distributed-ci.io                  |    /etc/letsencrypt/pem/lecm-test.distributed-ci.io.pem   |  89  |
-  | lecm-test-test.distributed-ci.io | Not-Generated | DNS;lecm-test-test.distributed-ci.io,DNS:lecm.distributedi-ci.io | /etc/letsencrypt/pem/lecm-test-test.distributed-ci.io.pem | N/A  |
-  +----------------------------------+---------------+------------------------------------------------------------------+-----------------------------------------------------------+------+
+ +--------- +----------------------------------+---------------+------------------------------------------------------------------+-----------------------------------------------------------+------+
+ |  In Sync |               Item               |     Status    |                          subjectAltName                          |                          Location                         | Days |
+ +--------- +----------------------------------+---------------+------------------------------------------------------------------+-----------------------------------------------------------+------+
+ |  True    |   lecm-test.distributed-ci.io    |   Generated   |                 DNS:lecm-test.distributed-ci.io                  |    /etc/letsencrypt/pem/lecm-test.distributed-ci.io.pem   |  89  |
+ |  False   | lecm-test-test.distributed-ci.io | Not-Generated | DNS;lecm-test-test.distributed-ci.io,DNS:lecm.distributedi-ci.io | /etc/letsencrypt/pem/lecm-test-test.distributed-ci.io.pem | N/A  |
+ +----------+----------------------------------+---------------+------------------------------------------------------------------+-----------------------------------------------------------+------+
 
 
 ``--list-details``
@@ -84,12 +84,12 @@ if its expiry date is lower than the ``remainin_days`` value.
 
 .. code-block::
 
-  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------+-----------------------------------------------------------+------+------+--------+------+
-  |               Item               |     Status    |                          subjectAltName                          |        emailAddress       |  Environment |                          Location                         | Type | Size | Digest | Days |
-  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------+-----------------------------------------------------------+------+------+--------+------+
-  |   lecm-test.distributed-ci.io    |   Generated   |                 DNS:lecm-test.distributed-ci.io                  | distributed-ci@redhat.com |  production  |    /etc/letsencrypt/pem/lecm-test.distributed-ci.io.pem   | RSA  | 4096 | sha256 |  89  |
-  | lecm-test-test.distributed-ci.io | Not-Generated | DNS;lecm-test-test.distributed-ci.io,DNS:lecm.distributedi-ci.io | distributed-ci@redhat.com |    staging   | /etc/letsencrypt/pem/lecm-test-test.distributed-ci.io.pem | RSA  | 2048 | sha256 | N/A  |
-  +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------|-----------------------------------------------------------+------+------+--------+------+
+  +--------- +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------+-----------------------------------------------------------+------+------+--------+------+
+  |  In Sync |               Item               |     Status    |                          subjectAltName                          |        emailAddress       |  Environment |                          Location                         | Type | Size | Digest | Days |
+  +--------- +----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------+-----------------------------------------------------------+------+------+--------+------+
+  |  True    |   lecm-test.distributed-ci.io    |   Generated   |                 DNS:lecm-test.distributed-ci.io                  | distributed-ci@redhat.com |  production  |    /etc/letsencrypt/pem/lecm-test.distributed-ci.io.pem   | RSA  | 4096 | sha256 |  89  |
+  |  False   | lecm-test-test.distributed-ci.io | Not-Generated | DNS;lecm-test-test.distributed-ci.io,DNS:lecm.distributedi-ci.io | distributed-ci@redhat.com |    staging   | /etc/letsencrypt/pem/lecm-test-test.distributed-ci.io.pem | RSA  | 2048 | sha256 | N/A  |
+  +----------+----------------------------------+---------------+------------------------------------------------------------------+---------------------------+--------------|-----------------------------------------------------------+------+------+--------+------+
 
 
 Configuration

--- a/lecm/lists.py
+++ b/lecm/lists.py
@@ -20,7 +20,8 @@ import os
 
 
 def list(certificates):
-    result = [['Item', []],
+    result = [['In Sync', []],
+              ['Item', []],
               ['Status', []],
               ['subjectAltName', []],
               ['Location', []],
@@ -28,20 +29,22 @@ def list(certificates):
     for name, parameters in certificates.items():
         cert = certificate.Certificate(parameters)
 
-        result[0][1].append(cert.name)
+        result[0][1].append(utils.is_sync(parameters))
+        result[1][1].append(cert.name)
         if os.path.exists('%s/pem/%s.pem' % (cert.path, cert.name)):
-            result[1][1].append('Generated')
+            result[2][1].append('Generated')
         else:
-            result[1][1].append('Not-Generated')
-        result[2][1].append(cert.subjectAltName)
-        result[3][1].append('%s/pem/%s.pem' % (cert.path, cert.name))
-        result[4][1].append(cert.days_before_expiry)
+            result[2][1].append('Not-Generated')
+        result[3][1].append(cert.subjectAltName)
+        result[4][1].append('%s/pem/%s.pem' % (cert.path, cert.name))
+        result[5][1].append(cert.days_before_expiry)
 
     utils.output_informations(result)
 
 
 def list_details(certificates):
-    result = [['Item', []],
+    result = [['In Sync', []],
+              ['Item', []],
               ['Status', []],
               ['subjectAltName', []],
               ['emailAddress', []],
@@ -54,18 +57,19 @@ def list_details(certificates):
     for name, parameters in certificates.items():
         cert = certificate.Certificate(parameters)
 
-        result[0][1].append(cert.name)
+        result[0][1].append(utils.is_sync(parameters))
+        result[1][1].append(cert.name)
         if os.path.exists('%s/pem/%s.pem' % (cert.path, cert.name)):
-            result[1][1].append('Generated')
+            result[2][1].append('Generated')
         else:
-            result[1][1].append('Not-Generated')
-        result[2][1].append(cert.subjectAltName)
-        result[3][1].append(cert.subject['emailAddress'])
-        result[4][1].append(cert.environment)
-        result[5][1].append('%s/pem/%s.pem' % (cert.path, cert.name))
-        result[6][1].append(cert.type)
-        result[7][1].append(cert.size)
-        result[8][1].append(cert.digest)
-        result[9][1].append(cert.days_before_expiry)
+            result[2][1].append('Not-Generated')
+        result[3][1].append(cert.subjectAltName)
+        result[4][1].append(cert.subject['emailAddress'])
+        result[5][1].append(cert.environment)
+        result[6][1].append('%s/pem/%s.pem' % (cert.path, cert.name))
+        result[7][1].append(cert.type)
+        result[8][1].append(cert.size)
+        result[9][1].append(cert.digest)
+        result[10][1].append(cert.days_before_expiry)
 
     utils.output_informations(result)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist = True
-envlist = pep8,py27,py34
+envlist = pep8
 
 [testenv]
 deps = -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Add an 'In Sync' flag in the output of `--list` and `--list-details` to show if configuration and the actual certificates (when they exist) are in sync or not.
    
To be considered to be 'in sync' both environment and subjectAltName should be matching.