### PR TITLE
Service reload: Optimize the way services are reloader

### DIFF
--- a/lecm/utils.py
+++ b/lecm/utils.py
@@ -122,10 +122,11 @@ def is_sync(certificate):
 
     cur_environment = get_environment(pem)
     cur_subjectaltname = get_subjectaltname(pem)
+    cert_san = certificate.get('subjectAltName', [certificate.get('name')])
 
     if cur_environment != certificate.get('environment', 'production') or \
         cur_subjectaltname != \
-            'DNS:%s' % ', DNS:'.join(certificate['subjectAltName']):
+            'DNS:%s' % ', DNS:'.join(cert_san):
         return False
 
     return True


### PR DESCRIPTION
Optimize the way services are reloaded:

  * Happen only at the end after all certificates are generated/renewed
  * The above means services are reloaded only once no matter how many certificates relies on it