### PR TITLE
Add note about serving challenge files via HTTP

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -170,7 +170,8 @@ Httpd and Nginx
 ``lecm`` does not configure the webservers, they have to be previously
 configured to be able to answer the challenges. NOTE: Let's
 Encrypt will perform a plain HTTP request to port 80 on your server, so you
-must serve the challenge files via HTTP.
+must serve the challenge files via HTTP. See the HTTP Challenge section
+of the `ACME specification`_ for more details.
 
 httpd
 ^^^^^
@@ -205,3 +206,4 @@ nginx
 
 .. _Let's Encrypt: https://letsencrypt.org/
 .. _official Debian package for lecm: https://tracker.debian.org/pkg/lecm
+.. _ACME specification: https://tools.ietf.org/html/draft-ietf-acme-acme-07#section-8.3

--- a/README.rst
+++ b/README.rst
@@ -168,7 +168,9 @@ Httpd and Nginx
 ---------------
 
 ``lecm`` does not configure the webservers, they have to be previously
-configured to be able to answer the challenges.
+configured to be able to answer the challenges. NOTE: Let's
+Encrypt will perform a plain HTTP request to port 80 on your server, so you
+must serve the challenge files via HTTP.
 
 httpd
 ^^^^^


### PR DESCRIPTION
I configured a server as https only. Then when renewal day came, Let's Encrypt could not access the challenge key anymore (and lecm displayed a stack trace where info was difficult to find). I propose to add a notice (sentence copied from the README.md from acme-tiny) so that this requirement is more obvious.