### PR TITLE
enabling the use of a generic challenge dir

### DIFF
--- a/lecm/configuration.py
+++ b/lecm/configuration.py
@@ -22,11 +22,27 @@ import yaml
 
 LOG = logging.getLogger(__name__)
 
-_FIELDS = ['type', 'size', 'digest', 'version', 'subjectAltName',
-           'countryName', 'stateOrProvinceName', 'localityName',
-           'organizationName', 'organizationUnitName', 'commonName',
-           'emailAddress', 'account_key_name', 'path', 'remaining_days',
-           'service_name', 'service_provider', 'environment']
+_FIELDS = [
+    "type",
+    "size",
+    "digest",
+    "version",
+    "subjectAltName",
+    "countryName",
+    "stateOrProvinceName",
+    "localityName",
+    "organizationName",
+    "organizationUnitName",
+    "commonName",
+    "emailAddress",
+    "account_key_name",
+    "path",
+    "remaining_days",
+    "service_name",
+    "service_provider",
+    "environment",
+    "use_generic_challenge_dir",
+]
 
 
 def check_configuration_file_existence(configuration_file_path=None):


### PR DESCRIPTION
This commit adds a new configuration parameter,
use_generic_challenge_dir, in order to simplify the http server
configuration.

Using a generic challenge dir enables the use of a generic snippet
shared between multiple vhosts.