### PR TITLE
Fix yaml.load deprecated usage

### DIFF
--- a/lecm/configuration.py
+++ b/lecm/configuration.py
@@ -68,7 +68,7 @@ def load_configuration(conf):
         raise exceptions.ConfigurationExceptions(exc)
 
     try:
-        conf = yaml.load(file_path_content)
+        conf = yaml.load(file_path_content, Loader=yaml.FullLoader)
     except yaml.YAMLError as exc:
         raise exceptions.ConfigurationExceptions(exc)
 


### PR DESCRIPTION
As per https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation
yaml.load usage without specifying any Loader has been deprecated for a long time. 

It currently triggers the warning:
/usr/lib/python3/dist-packages/lecm/configuration.py:71: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
  conf = yaml.load(file_path_content)

This patch explicitly specifies the Loader to use.