### PR TITLE
Certificate: Roll-out from X3 intermediate to R3

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -26,7 +26,7 @@ import subprocess
 LOG = logging.getLogger(__name__)
 
 _INTERMEDIATE_CERTIFICATE_URL = \
-    'https://letsencrypt.org/certs/lets-encrypt-x3-cross-signed.pem'
+    'https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem'
 
 _STAGING_URL = \
     'https://acme-staging.api.letsencrypt.org'


### PR DESCRIPTION
Since December 2020, the X3 intermediate certificate is not being used
for new certificates, roll-out to the "new" R3 in production.

Refs: https://letsencrypt.org/certificates/
Refs: https://letsencrypt.org/2020/09/17/new-root-and-intermediates.html
Closes: https://github.com/Spredzy/lecm/issues/62