### PR TITLE
Change intermediate certificate to R3 signed by X1

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -26,7 +26,7 @@ import subprocess
 LOG = logging.getLogger(__name__)
 
 _INTERMEDIATE_CERTIFICATE_URL = \
-    'https://letsencrypt.org/certs/lets-encrypt-r3-cross-signed.pem'
+    'https://letsencrypt.org/certs/lets-encrypt-r3.pem'
 
 _STAGING_URL = \
     'https://acme-staging.api.letsencrypt.org'


### PR DESCRIPTION
According to https://letsencrypt.org/certificates/ , the current
certificate is "Let's Encrypt R3 Cross-signed by IdenTrust", which
expires on 2021-09-29.

This patch changes to the current newest which is "Let's Encrypt R3
Signed by ISRG Root X1".