### PR TITLE
Stop using deprecated intermediate certificates

### DIFF
--- a/contrib/packaging/rpm/lecm.spec
+++ b/contrib/packaging/rpm/lecm.spec
@@ -19,7 +19,6 @@ BuildRequires:  python3-devel
 Requires:       acme-tiny
 Requires:       python3-prettytable
 Requires:       python3-PyYAML
-Requires:       python3-requests
 Requires:       python3-pyOpenSSL
 
 %description

--- a/lecm/configuration.py
+++ b/lecm/configuration.py
@@ -68,7 +68,7 @@ def load_configuration(conf):
         raise exceptions.ConfigurationExceptions(exc)
 
     try:
-        conf = yaml.load(file_path_content, Loader=yaml.FullLoader)
+        conf = yaml.safe_load(file_path_content)
     except yaml.YAMLError as exc:
         raise exceptions.ConfigurationExceptions(exc)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,3 @@ acme-tiny
 PrettyTable
 pyOpenSSL
 PyYAML
-requests


### PR DESCRIPTION
Lecm currently concatenates an intermediate cert
`lets-encrypt-r3-cross-signed.pem` which is deprecated and expires on
September 29, 2021.

In addition, Let's Encrypt now returns the full chain along with the
certificate, adding hardcoded intermediate is not even necessary
anymore.

This change does the following:
- stop adding the intermediate certificate to the cert
- stop writing the intermediate certificate file
- split the chained certificates into a `<name>-chain.pem` file for
  software which still need separate chain certificates in a separate
  file.

Also use PyYaml `SafeLoader` instead of `FullLoader` to avoid warnings & support older releases of PyYaml.