### PR TITLE
Fix deprecated platform

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -320,7 +320,8 @@ class Certificate(object):
             self._create_account_key()
         self._create_private_key()
         self._create_csr()
-        os.makedirs('%s/challenges/%s' % (self.path, self.name))
+        if not os.path.exists('%s/challenges/%s' % (self.path, self.name)):
+            os.makedirs('%s/challenges/%s' % (self.path, self.name))
         self._create_certificate()
 
     def renew(self):

--- a/lecm/utils.py
+++ b/lecm/utils.py
@@ -15,6 +15,7 @@
 
 from prettytable import PrettyTable
 from OpenSSL import crypto
+from distro import linux_distribution
 
 import copy
 import logging
@@ -45,8 +46,7 @@ def filter_certificates(items, certificates):
 
 
 def enforce_selinux_context(output_directory):
-
-    if platform.dist()[0] in ['fedora', 'centos', 'redhat']:
+    if linux_distribution()[0] in ['fedora', 'centos', 'redhat']:
         if os.path.exists('/sbin/semanage'):
             FNULL = open(os.devnull, 'w')
 


### PR DESCRIPTION
Fix of #71

Based on https://github.com/psychopy/psychopy/pull/2735/commits/f0caec756ba0d95b5c919a9db3cf8eaea25d8dc0

Also when I rerun the tool it was anyway failed because it ried to create the `challenges` folder but it already exists
