### PR TITLE
Set default cert version to 0 when unspecified

### DIFF
--- a/lecm/certificate.py
+++ b/lecm/certificate.py
@@ -37,7 +37,7 @@ class Certificate(object):
         self.type = conf.get('type', 'RSA')
         self.size = conf.get('size', 4096)
         self.digest = conf.get('digest', 'sha256')
-        self.version = conf.get('version', 3)
+        self.version = conf.get('version', 0)
         self.environment = conf.get('environment', 'production')
         self.subjectAltName = self.normalize_san(conf.get('subjectAltName'))
         self.account_key_name = conf.get('account_key_name',


### PR DESCRIPTION
Following a Debian upgrade to Trixie, pyOpenSSL (used through lecm)complained "Invalid version. The only valid version for X509Req is 0".